### PR TITLE
Added play detail page and supporting /api/play/<play_id> endpoint. Updated URL routing.

### DIFF
--- a/statler_api/urls.py
+++ b/statler_api/urls.py
@@ -7,6 +7,10 @@ urlpatterns = [
     # urls that look like /api/health-check/ are forwarded to
     # the views.healthCheck function
     url(r'^health-check/$', views.healthCheck, name='health-check'),
+
+    # urls that look like /api/play/<play_id>/ are forwarded to
+    # the views.getPlayDetail function
+    url(r'^play/(?P<play_id>[^,/]+)/$', views.getPlayDetail, name='play-detail'),
     
     # urls that look like /api/play-list/ are forwarded to
     # the views.getPlayList function

--- a/statler_api/views.py
+++ b/statler_api/views.py
@@ -1,16 +1,24 @@
 from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
 from django.core import serializers
 from .models import Play
 
 def healthCheck(request):
     """Returns a string. This shouldn't break. We can use this
     to confirm the server is on its feet."""
-
     return HttpResponse("The API is alive.")
 
 def getPlayList(request):
     """called when a GET request is sent to /api/play-list/
     returns json of the list of plays
     see https://docs.djangoproject.com/en/1.8/topics/serialization/"""
-    
-    return HttpResponse(serializers.serialize("json", Play.objects.all()))
+    playList = Play.objects.all()
+    #TODO: wrap playList in another object to control what fields are sent
+    return HttpResponse(serializers.serialize("json", playList))
+
+def getPlayDetail(request, play_id):
+    """called when a GET request is sent to /api/play/<play_id>
+    returns json for the play"""
+    play = get_object_or_404(Play, url_title=play_id)
+    #TODO: wrap play in another object to control what fields are sent
+    return HttpResponse(serializers.serialize("json", [play]))

--- a/statler_site/admin.py
+++ b/statler_site/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/statler_site/models.py
+++ b/statler_site/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/statler_site/templates/play-detail-page.html
+++ b/statler_site/templates/play-detail-page.html
@@ -8,7 +8,7 @@
 
       // This string will be filled out by Django when the page is served.
       // It contains the URL to make an API call to
-      var apiEndpointUrl = '{% url 'api:play-list' %}';
+      var apiEndpointUrl = '{% url 'api:play-detail' play_id %}';
 
       // jQuery code normally starts with the .ready function
       $(document).ready(function(){

--- a/statler_site/urls.py
+++ b/statler_site/urls.py
@@ -5,6 +5,8 @@ from . import views
 # This is where the magical regex mapping happens.
 urlpatterns = [
     url(r'^health-check/$', views.healthCheck, name='health-check'),
+
+    url(r'^(?P<play_id>[^,/]+)/$',views.getPlayDetailPage, name='play-detail'),
     
     # blank urls are forwarded to
     # the views.getPlayListPage function

--- a/statler_site/views.py
+++ b/statler_site/views.py
@@ -1,15 +1,18 @@
 from django.shortcuts import render, render_to_response
 from django.http import HttpResponse
+from statler_api.models import Play
 
 def healthCheck(request):
     """Returns a string. This shouldn't break. We can use this
     to confirm the server is on its feet."""
-
     return HttpResponse("The site is alive.")
 
-
 def getPlayListPage(request):
-    """returns a static html page which will use a script
+    """returns a static html page which will use JavaScript
     to get and display data"""
-    
     return render_to_response('play-list-page.html')
+
+def getPlayDetailPage(request, play_id):
+    """returns a static html page which will use JavaScript
+    to get and display data"""
+    return render(request, 'play-detail-page.html', {'play_id': play_id})


### PR DESCRIPTION
If you create a play with a url_title of 'romeo-and-juliet', for example, then you can go to localhost:8000/romeo-and-juliet to see the new page.
