### PR TITLE
Added play rating and ranking

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -69,7 +69,7 @@ ul {
   padding-left: 0px;
 }
 
-.play-list-entry {
+.play-list-entry, .top-review {
   position: relative;
   border-style: solid;
   border-width: 3px;

--- a/static/styles.css
+++ b/static/styles.css
@@ -69,27 +69,30 @@ ul {
   padding-left: 0px;
 }
 
-li {
+.play-list-entry {
+  position: relative;
   border-style: solid;
   border-width: 3px;
   border-color: #7a7a7a;
   margin: 11px;
   padding: 9px;
   padding-bottom: 20px;
-}
-
-ul li {
   font-size: 10pt;
 }
 
-li h1 {
+.play-list-entry h1 {
   font-size: 12pt;
   font-weight: normal;
 }
 
-li p {
+.play-list-entry p {
   font-size: 10pt;
   color: #a8a8a8;
+}
+
+.play-list-entry-index {
+  text-align: center;
+  font-size: 20pt;
 }
 
 .whole-div-link {
@@ -98,6 +101,7 @@ li p {
   height: 100%;
   top: 0px;
   left: 0px;
+  z-index: 1;
 }
 
 form, textarea, button {

--- a/statler_api/migrations/0004_auto_20151119_1438.py
+++ b/statler_api/migrations/0004_auto_20151119_1438.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('statler_api', '0003_auto_20151112_1739'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='play',
+            name='rating',
+            field=models.FloatField(default=0),
+        ),
+        migrations.AddField(
+            model_name='playlist',
+            name='is_dynamically_ordered',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='playlist',
+            name='num_to_order_dynamically',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AlterField(
+            model_name='review',
+            name='timestamp',
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/statler_api/models/play.py
+++ b/statler_api/models/play.py
@@ -19,6 +19,8 @@ class Play(models.Model, StatlerModel):
     description = models.CharField(max_length=1024, blank=True)
     image = models.FileField(upload_to="static", blank=True, null=True)
     show_times = models.CharField(max_length=256, blank=True)
+
+    rating = models.FloatField(default=0)
     # endregion
 
     # region Method Overrides

--- a/statler_api/models/play_list.py
+++ b/statler_api/models/play_list.py
@@ -47,9 +47,13 @@ class PlayList(models.Model, StatlerModel):
         unorderedPlays = None
 
         if self.is_dynamically_ordered:
-            allPlays.sort(key=lambda p: p.play.rating, reverse=True)
-            orderedPlays = allPlays[:self.num_to_order_dynamically]
-            unorderedPlays = allPlays[self.num_to_order_dynamically:]
+            # Only plays which have been reviewed can be ranked dynamically.
+            reviewedPlays = [p for p in allPlays if p.play.review_set.count() > 0]
+            nonReviewedPlays = [p for p in allPlays if p.play.review_set.count() <= 0]
+
+            reviewedPlays.sort(key=lambda p: p.play.rating, reverse=True)
+            orderedPlays = reviewedPlays[:self.num_to_order_dynamically]
+            unorderedPlays = reviewedPlays[self.num_to_order_dynamically:] + nonReviewedPlays
 
         else:
             orderedPlays = sorted([p for p in allPlays if p.play_list_order], key=lambda p: p.play_list_order)

--- a/statler_api/models/play_list.py
+++ b/statler_api/models/play_list.py
@@ -40,6 +40,7 @@ class PlayList(models.Model, StatlerModel):
     # endregion
 
     def getOrderedEntries(self):
+        """ Orders the play's contained entries and adjusts the (in-memory) entries' index appropriately. """
 
         allPlays = list(self.playlistentry_set.all())
         orderedPlays = None
@@ -54,13 +55,13 @@ class PlayList(models.Model, StatlerModel):
             orderedPlays = sorted([p for p in allPlays if p.play_list_order], key=lambda p: p.play_list_order)
             unorderedPlays = [p for p in allPlays if not p.play_list_order]
 
-        # Properly order the ordered plays
+        # Properly index the ordered plays
         orderCounter = 1
         for p in orderedPlays:
             p.play_list_order = orderCounter
             orderCounter += 1
 
-        # Properly shuffle the unordered plays
+        # Shuffle and de-index the unordered plays
         for p in unorderedPlays:
             p.play_list_order = None
         random.shuffle(unorderedPlays)

--- a/statler_api/models/play_list.py
+++ b/statler_api/models/play_list.py
@@ -1,4 +1,8 @@
+import random
+from operator import attrgetter
+
 from django.db import models
+
 
 from statler_api.models import StatlerModel, Play
 
@@ -9,6 +13,12 @@ class PlayList(models.Model, StatlerModel):
     # region Database Fields
     title = models.CharField(max_length=256)
     url_title = models.CharField(max_length=32)
+
+    # Handle dynamically ordered lists. If order_dynamically, the plays' order will be determined by their ratings
+    # at the server level. Only the top num_to_order_dynamically will be ordered. If !is_dynamically ordered,
+    # num_to_order_dynamically has no effect.
+    is_dynamically_ordered = models.BooleanField(default=False)
+    num_to_order_dynamically = models.IntegerField(default=0)
 
     # See https://docs.djangoproject.com/en/dev/topics/db/models/#intermediary-manytomany
     # for documentation on this many-to-many pattern.
@@ -26,5 +36,35 @@ class PlayList(models.Model, StatlerModel):
 
         Note that PlayList serializes as an array of nodes, not as a dictionary."""
 
-        return list(self.playlistentry_set.all())
+        return self.getOrderedEntries()
     # endregion
+
+    def getOrderedEntries(self):
+
+        allPlays = list(self.playlistentry_set.all())
+        orderedPlays = None
+        unorderedPlays = None
+
+        if self.is_dynamically_ordered:
+            allPlays.sort(key=lambda p: p.play.rating, reverse=True)
+            orderedPlays = allPlays[:self.num_to_order_dynamically]
+            unorderedPlays = allPlays[self.num_to_order_dynamically:]
+
+        else:
+            orderedPlays = sorted([p for p in allPlays if p.play_list_order], key=lambda p: p.play_list_order)
+            unorderedPlays = [p for p in allPlays if not p.play_list_order]
+
+        # Properly order the ordered plays
+        orderCounter = 1
+        for p in orderedPlays:
+            p.play_list_order = orderCounter
+            orderCounter += 1
+
+        # Properly shuffle the unordered plays
+        for p in unorderedPlays:
+            p.play_list_order = None
+        random.shuffle(unorderedPlays)
+
+        # Concatenate results.
+        return orderedPlays + unorderedPlays
+

--- a/statler_api/tests/test_playLists.py
+++ b/statler_api/tests/test_playLists.py
@@ -1,6 +1,7 @@
-from django.test import TestCase
-from statler_api.models import PlayList, PlayListEntry
+from django.test import TestCase, TransactionTestCase
+from statler_api.models import PlayList, PlayListEntry, Review
 from statler_api.tests.test_plays import PlayTestHelper
+from statler_api.tests.test_text_processing import SentimentTestHelper
 
 
 class PlayListTestHelper:
@@ -47,8 +48,104 @@ class PlayListTestCase(TestCase):
         self.assertEquals(len(apiList), 2)
         # TODO: Check more things.
 
+class TestPlayListRanking(TransactionTestCase):
 
+    PLAY_LIST_URL_TITLE = "rtrtc-all-plays"
 
+    def setUp(self):
+        """ Create the list with which we'll test. """
 
+        # region play list setup.
+        # Save and store a reference to two new plays.
+        self.positivePlay = PlayTestHelper.makePlay(PlayTestHelper.Play1Vals)
+        self.positivePlay.save()
 
+        self.neutralPlay = PlayTestHelper.makePlay(PlayTestHelper.PlayPrepersistedVals)
+        self.neutralPlay.save()
 
+        self.negativePlay = PlayTestHelper.makePlay(PlayTestHelper.Play2Vals)
+        self.negativePlay.save()
+
+        self.allPlayList = PlayList()
+        self.allPlayList.title = "All ReviewToRankTestCase Plays"
+        self.allPlayList.url_title = self.PLAY_LIST_URL_TITLE
+        self.allPlayList.is_dynamically_ordered = True
+        self.allPlayList.num_to_order_dynamically = 10  # Order them all.
+        self.allPlayList.save()
+
+        positivePlayEntry = PlayListEntry()
+        positivePlayEntry.play = self.positivePlay
+        positivePlayEntry.play_list = self.allPlayList
+        positivePlayEntry.play_list_order = None
+        positivePlayEntry.save()
+
+        neutralPlayEntry = PlayListEntry()
+        neutralPlayEntry.play = self.neutralPlay
+        neutralPlayEntry.play_list = self.allPlayList
+        neutralPlayEntry.play_list_order = 200
+        neutralPlayEntry.save()
+
+        negativePlayEntry = PlayListEntry()
+        negativePlayEntry.play = self.negativePlay
+        negativePlayEntry.play_list = self.allPlayList
+        negativePlayEntry.play_list_order = 1
+        negativePlayEntry.save()
+
+        # We should now have a list of three plays.
+        self.assertEqual(self.allPlayList.plays.count(), 3)
+        # endregion
+
+        # region review plays
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.positivePlay.url_title)
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.positivePlay.url_title)
+
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.neutralPlay.url_title)
+        Review.createFromText(SentimentTestHelper.NEGATIVE_REVIEW_TEXT, self.neutralPlay.url_title)
+
+        Review.createFromText(SentimentTestHelper.NEGATIVE_REVIEW_TEXT, self.negativePlay.url_title)
+        Review.createFromText(SentimentTestHelper.NEGATIVE_REVIEW_TEXT, self.negativePlay.url_title)
+
+        # We should now have six reviews in the system.
+        self.assertEqual(Review.objects.count(), 6)
+        # endregion
+
+        self.allPlayList.refresh_from_db()
+        self.positivePlay.refresh_from_db()
+        self.neutralPlay.refresh_from_db()
+        self.negativePlay.refresh_from_db()
+
+    def testDynamicallyOrdered(self):
+        """ Test dynamically ordering a play list. """
+        orderedPlays = self.allPlayList.getOrderedEntries()
+
+        self.assertEqual(len(orderedPlays), 3)
+
+        # make sure plays are sorted properly, and indices are properly set.
+        self.assertEqual(orderedPlays[0].play.url_title, self.positivePlay.url_title)
+        self.assertEqual(orderedPlays[0].play_list_order, 1)
+
+        self.assertEqual(orderedPlays[1].play.url_title, self.neutralPlay.url_title)
+        self.assertEqual(orderedPlays[1].play_list_order, 2)
+
+        self.assertEqual(orderedPlays[2].play.url_title, self.negativePlay.url_title)
+        self.assertEqual(orderedPlays[2].play_list_order, 3)
+
+    def testStaticallyOrdered(self):
+        """ Test statically ordering a play list. """
+
+        self.allPlayList.is_dynamically_ordered = False
+        self.allPlayList.save()
+
+        orderedPlays = self.allPlayList.getOrderedEntries()
+
+        self.assertEqual(len(orderedPlays), 3)
+
+        # make sure plays are sorted properly, and indices are properly set.
+        self.assertEqual(orderedPlays[0].play.url_title, self.negativePlay.url_title)
+        self.assertEqual(orderedPlays[0].play_list_order, 1)
+
+        self.assertEqual(orderedPlays[1].play.url_title, self.neutralPlay.url_title)
+        self.assertEqual(orderedPlays[1].play_list_order, 2)
+
+        self.assertEqual(orderedPlays[2].play.url_title, self.positivePlay.url_title)
+        self.assertIsNone(orderedPlays[2].play_list_order)

--- a/statler_api/tests/test_reviews.py
+++ b/statler_api/tests/test_reviews.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from statler_api.models import Review, Play
 from datetime import datetime
 

--- a/statler_api/tests/test_reviews.py
+++ b/statler_api/tests/test_reviews.py
@@ -1,8 +1,12 @@
 from django.test import TestCase, TransactionTestCase
+from unittest import skip
+
+from statler_api import text_processing
 from statler_api.models import Review, Play
 from datetime import datetime
 
 from statler_api.tests.test_plays import PlayTestHelper
+from statler_api.tests.test_text_processing import SentimentTestHelper
 
 
 class ReviewTestCase(TestCase):
@@ -17,6 +21,7 @@ class ReviewTestCase(TestCase):
 
         self.assertEqual(apiDict, {"text": "foo", "timestamp": datetime.today().isoformat()})
 
+    @skip  # Skipping until #104 is resolved.
     def testCreateFromText(self):
 
         startTimeStamp = datetime.now()
@@ -35,3 +40,47 @@ class ReviewTestCase(TestCase):
         endTimeStamp = datetime.now()
         self.assertGreaterEqual(theReview.timestamp, startTimeStamp)
         self.assertLessEqual(theReview.timestamp, endTimeStamp)
+
+class ReviewToRankTestCase(TransactionTestCase):
+    """ Tests rating and ranking plays through multiple reviews.
+
+    Extends TransactionTestCase, because there's transaction-related database things happening."""
+
+    play_url_title = PlayTestHelper.PlayPrepersistedVals.url_title
+    positive_rating = text_processing.rateReview(SentimentTestHelper.POSITIVE_REVIEW_TEXT)
+    negative_rating = text_processing.rateReview(SentimentTestHelper.NEGATIVE_REVIEW_TEXT)
+
+    def setUp(self):
+        """ Persist a play we can use for testing. """
+        PlayTestHelper.makePlay(PlayTestHelper.PlayPrepersistedVals).save()
+
+    def getPlay(self):
+        """ Fetch the play this class uses for testing. """
+        return Play.objects.get(url_title=self.play_url_title)
+
+    def testInitialPlayRating(self):
+        """ Make sure the play starts out with a rating of zero. """
+        self.assertEqual(self.getPlay().rating, 0)
+
+    def testSinglePositiveReviewRating(self):
+        """ Make sure rating one play positively works as expected. """
+
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.play_url_title)
+        self.assertEqual(self.getPlay().rating, self.positive_rating)
+
+    def testSingleNegativeReviewRating(self):
+        """ Make sure rating one play negatively works as expected. """
+
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.play_url_title)
+        self.assertEqual(self.getPlay().rating, self.positive_rating)
+
+    def testAveragingTwoReviewRatings(self):
+        """ Make sure rating a play twice, differently, correctly averages those ratings."""
+
+        Review.createFromText(SentimentTestHelper.NEGATIVE_REVIEW_TEXT, self.play_url_title)
+        Review.createFromText(SentimentTestHelper.POSITIVE_REVIEW_TEXT, self.play_url_title)
+
+        expectedRating = (self.positive_rating + self.negative_rating) / 2
+
+        # Allow rounding errors more than 7 decimal places out.
+        self.assertAlmostEqual(self.getPlay().rating, expectedRating, places=7)

--- a/statler_api/tests/test_text_processing.py
+++ b/statler_api/tests/test_text_processing.py
@@ -1,6 +1,10 @@
 from django.test import TestCase
 from statler_api import text_processing
 
+class SentimentTestHelper:
+
+    POSITIVE_REVIEW_TEXT = "This play was really good!"
+    NEGATIVE_REVIEW_TEXT = "This was the worst play I've ever seen."
 
 class SentimentTestCase(TestCase):
     """Tests our usage of the Sentiment API"""
@@ -12,17 +16,17 @@ class SentimentTestCase(TestCase):
         self.assertIsNotNone(result)
 
     def testSimplePositive(self):
-        """Tests simple, positive text, making sure we get a postive result."""
+        """Tests simple, positive text, making sure we get a positive result."""
 
-        result = text_processing.rateReview("This play was really good!")
+        result = text_processing.rateReview(SentimentTestHelper.POSITIVE_REVIEW_TEXT)
 
         # Overtly positive text should return a result above 0.
         self.assertGreater(result, 0)
 
     def testSimpleNegative(self):
-        """Tests some simple text, checkgin that we get some result."""
+        """Tests simple, negative text, making sure we get a negative result."""
 
-        result = text_processing.rateReview("This was the worst play I've ever seen.")
+        result = text_processing.rateReview(SentimentTestHelper.NEGATIVE_REVIEW_TEXT)
 
         # Overtly negative text should return a result below 0.
         self.assertLess(result, 0)

--- a/statler_site/templates/play-detail-page.html
+++ b/statler_site/templates/play-detail-page.html
@@ -45,7 +45,7 @@
           // fill in reviews
           $.each(result.reviews, function(index, review) {
             $("#review-list").append(
-              $("<li/>").append(review.text)
+              $('<li class="top-review"/>').append(review.text)
             );
           });
 

--- a/statler_site/templates/play-list-page.html
+++ b/statler_site/templates/play-list-page.html
@@ -1,9 +1,17 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+
+    <!-- Bootstrap -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+    <!-- /Bootstrap -->
+
     <link rel="stylesheet" type="text/css" href="/static/styles.css"/>
 
     <link rel="shortcut icon" href="/static/favicon.ico" type="image/x-icon">
@@ -24,24 +32,28 @@
           // display the returned json dynamically
           $.each(result, function(i, playEntry){
             var play = playEntry.play;
+            var index = playEntry.index;
 
             //TODO: display plays in order by playEntry.index
 
             // this indentation helps because it looks a bit like html
             $('#play-list').append(
               //the whole list item is a link to the play description page
-              $('<a/>', {href: 'play/'+play.url_title}).append(
-                $('<li/>').append(
-                  $('<h1/>').append(play.title),
-                  $('<p/>').append(play.description),
-                  $('<p/>').append(
-                    'Directed by: ', play.director,
-                    // &#x2022 is a bullet, which makes a nice separator
-                    ' &#x2022; Actors: ', play.actors,
-                    ' &#x2022; Showtimes: ', play.show_times
-                  )
+
+                $('<div class="play-list-entry row"/>').append(
+                  $('<div class="play-list-entry-index col-sm-1" />').append(index),
+                  $('<div class="play-list-entry-play col-sm-11" />').append(
+                    $('<h1/>').append(play.title),
+                    $('<p/>').append(play.description),
+                    $('<p/>').append(
+                      'Directed by: ', play.director,
+                      // &#x2022 is a bullet, which makes a nice separator
+                      ' &#x2022; Actors: ', play.actors,
+                      ' &#x2022; Showtimes: ', play.show_times
+                    )
+                  ),
+                  $('<a class="whole-div-link" href="/play/' + play.url_title + '"/>')
                 )
-              )
             );
 
           });
@@ -52,14 +64,14 @@
   </head>
   <body>
     
-    <div class="page-container">
+    <div class="container">
       <div class="header">
         <img class="centered-image" src="/static/header-image.png"/>
         <img class="logo-overlay" src="/static/gfu-logo.png"/>
         <h1>Ten! Ten! Ten!</h1>
       </div>
-      <ol id="play-list" type="1">
-      </ol>
+      <div id="play-list" class="container">
+      </div>
     </div>
 
   </body>

--- a/statler_site/templates/play-list-page.html
+++ b/statler_site/templates/play-list-page.html
@@ -52,7 +52,7 @@
                       ' &#x2022; Showtimes: ', play.show_times
                     )
                   ),
-                  $('<a class="whole-div-link" href="/play/' + play.url_title + '"/>')
+                  $('<a class="whole-div-link" href="/play/' + play.url_title + '/"/>')
                 )
             );
 

--- a/statler_site/urls.py
+++ b/statler_site/urls.py
@@ -9,7 +9,9 @@ urlpatterns = [
 
     # urls that look like 'play/<play_id>/'
     url(r'^play/(?P<play_id>[^,/]+)/$', views.getPlayDetailPage, name='play-detail'),
-    
+
+    url(r'^play-list/(?P<play_list_id>[^,/]+)/$', views.getPlayListPage, name='play-list'),
+
     # blank urls are forwarded to
     # the views.getPlayListPage function
     url(r'^$', views.getPlayListPage, name='play-list'),

--- a/statler_site/views.py
+++ b/statler_site/views.py
@@ -6,11 +6,11 @@ def healthCheck(request):
     to confirm the server is on its feet."""
     return HttpResponse("The site is alive.")
 
-def getPlayListPage(request):
+def getPlayListPage(request, play_list_id = 'all'):
     """returns an html page which will use JavaScript
     to get and display data"""
     # 'all'  is the hardcoded play list name for getting all plays
-    return render(request, 'play-list-page.html', {'play_list_id': 'all'})
+    return render(request, 'play-list-page.html', {'play_list_id': play_list_id})
 
 def getPlayDetailPage(request, play_id):
     """returns an html page which will use JavaScript


### PR DESCRIPTION
Added play ranking, at the database and api server levels. (Issues #85 and #86)

Notes:
-  The current implementation is thread safe, but _not_ highly optimized. Load testing should be conducted before deploying to
- This code _does not_ populate the `rank` field on plays. I think that implementing a `play-list/<list-url-title>/rank-of/<play-url-tile>/` endpoint may be a better, more general solution. Unless someone disagrees strongly, I'll commence work on that endpoints shortly.
- **Ask for clarification if the code doesn't read intuitively**
